### PR TITLE
Send the original request method to the API

### DIFF
--- a/docs/API-Specification.md
+++ b/docs/API-Specification.md
@@ -11,7 +11,7 @@ Endpoints
 APIs should have a single `GET` endpoint. Thundermole will make a request like this:
 
 ```
-GET /path/to?resource={resource_path} HTTP/1.1
+GET /path/to?method={method}&resource={resource_path} HTTP/1.1
 Host: example.com
 Accept: application/json
 Connection: keep-alive
@@ -19,6 +19,8 @@ Cookie: {cookie}
 ```
 
 In this request:
+
+`{method}` will be set to the method of original request that came into Thundermole. e.g. `GET` or `POST`.
 
 `{resource_path}` will be set to the full path of the original request that came into Thundermole. This will include query parameters which can be parsed by the API.
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -58,6 +58,7 @@ function buildApiRequest (incomingRequest, routes) {
 		method: 'GET',
 		url: module.exports.buildApiRequestUrl(incomingRequest.url, routes),
 		qs: {
+			method: incomingRequest.method,
 			resource: parseUrl(incomingRequest.url).path
 		},
 		headers: {

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -19,6 +19,7 @@
 
 var assert = require('proclaim');
 var describeRequest = require('./helper/describe-request');
+var url = require('url');
 
 describe('Thundermole ➞ Default API ➞ Default Backend', function () {
 
@@ -51,11 +52,29 @@ describe('Thundermole ➞ Default API ➞ Default Backend', function () {
 
 	});
 
+	describeRequest('GET', '/foo', null, function () {
+
+		it('should send the request method to the API', function () {
+			var query = url.parse(this.testApps.apiDefault.lastRequest.url, true).query;
+			assert.strictEqual(query.method, 'GET');
+		});
+
+	});
+
+	describeRequest('POST', '/foo', null, function () {
+
+		it('should send the request method to the API', function () {
+			var query = url.parse(this.testApps.apiDefault.lastRequest.url, true).query;
+			assert.strictEqual(query.method, 'POST');
+		});
+
+	});
+
 	describeRequest('GET', '/foo?bar=baz', null, function () {
 
 		it('should send the full path to the API', function () {
-			var apiRequest = this.testApps.apiDefault.lastRequest;
-			assert.strictEqual(apiRequest.url, '/api/routing?resource=%2Ffoo%3Fbar%3Dbaz');
+			var query = url.parse(this.testApps.apiDefault.lastRequest.url, true).query;
+			assert.strictEqual(query.resource, '/foo?bar=baz');
 		});
 
 	});
@@ -211,11 +230,29 @@ describe('Thundermole ➞ Test API ➞ Test Backend', function () {
 
 	});
 
+	describeRequest('GET', '/test/foo', null, function () {
+
+		it('should send the request method to the API', function () {
+			var query = url.parse(this.testApps.apiTest.lastRequest.url, true).query;
+			assert.strictEqual(query.method, 'GET');
+		});
+
+	});
+
+	describeRequest('POST', '/test/foo', null, function () {
+
+		it('should send the request method to the API', function () {
+			var query = url.parse(this.testApps.apiTest.lastRequest.url, true).query;
+			assert.strictEqual(query.method, 'POST');
+		});
+
+	});
+
 	describeRequest('GET', '/test/foo?bar=baz', null, function () {
 
 		it('should send the full path to the API', function () {
-			var apiRequest = this.testApps.apiTest.lastRequest;
-			assert.strictEqual(apiRequest.url, '/api/routing?resource=%2Ftest%2Ffoo%3Fbar%3Dbaz');
+			var query = url.parse(this.testApps.apiTest.lastRequest.url, true).query;
+			assert.strictEqual(query.resource, '/test/foo?bar=baz');
 		});
 
 	});

--- a/test/unit/lib/api.js
+++ b/test/unit/lib/api.js
@@ -156,6 +156,7 @@ describe('lib/api', function () {
 			incomingRequest = new http.IncomingMessage();
 			incomingRequest.url = 'http://example.com/foo/bar?baz=qux';
 			incomingRequest.headers.cookie = 'cookies!';
+			incomingRequest.method = 'POST';
 			routes = {
 				foo: 'foo-route'
 			};
@@ -180,6 +181,10 @@ describe('lib/api', function () {
 
 			it('should have a `qs` property set to an object', function () {
 				assert.isObject(builtRequest.qs);
+			});
+
+			it('should have a `qs.method` property set to the method of the original request', function () {
+				assert.strictEqual(builtRequest.qs.method, 'POST');
 			});
 
 			it('should have a `qs.resource` property set to the path/query of the original request', function () {

--- a/test/unit/mock/http.js
+++ b/test/unit/mock/http.js
@@ -23,7 +23,8 @@ var clientRequest = {
 };
 
 var incomingMessage = {
-	headers: {}
+	headers: {},
+	method: 'GET'
 };
 
 var serverResponse = {


### PR DESCRIPTION
This allows the API to determine the proxy target based on the original request's method.