### PR TITLE
User-Agent Header

### DIFF
--- a/docs/API-Specification.md
+++ b/docs/API-Specification.md
@@ -16,6 +16,7 @@ Host: example.com
 Accept: application/json
 Connection: keep-alive
 Cookie: {cookie}
+User-Agent: Thundermole/{version}
 ```
 
 In this request:
@@ -27,6 +28,8 @@ In this request:
 `{host}` will be set to the host header of the original request that came in to Thundermole.
 
 `{cookie}` will be set to the `Cookie` header of the original request that came into Thundermole, unchanged.
+
+`{version}` will be set to the version of Thundermole that is making the request.
 
 
 Responses

--- a/docs/API-Specification.md
+++ b/docs/API-Specification.md
@@ -11,7 +11,7 @@ Endpoints
 APIs should have a single `GET` endpoint. Thundermole will make a request like this:
 
 ```
-GET /path/to?method={method}&resource={resource_path}&host={host} HTTP/1.1
+GET /path/to?method={method}&resource={resource_path}&host={host}&useragent={useragent} HTTP/1.1
 Host: example.com
 Accept: application/json
 Connection: keep-alive
@@ -25,7 +25,9 @@ In this request:
 
 `{resource_path}` will be set to the full path of the original request that came into Thundermole. This will include query parameters which can be parsed by the API.
 
-`{host}` will be set to the host header of the original request that came in to Thundermole.
+`{host}` will be set to the `Host` header of the original request that came in to Thundermole.
+
+`{useragent}` will be set to the `User-Agent` header of the original request that came in to Thundermole.
 
 `{cookie}` will be set to the `Cookie` header of the original request that came into Thundermole, unchanged.
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -17,6 +17,7 @@
 
 var _ = require('underscore');
 var parseUrl = require('url').parse;
+var pkg = require('../package.json');
 var request = require('request');
 
 module.exports = {
@@ -62,7 +63,8 @@ function buildApiRequest (incomingRequest, routes) {
 			resource: parseUrl(incomingRequest.url).path
 		},
 		headers: {
-			Accept: 'application/json'
+			Accept: 'application/json',
+			'User-Agent': 'Thundermole/' + pkg.version
 		},
 		json: true
 	};

--- a/lib/api.js
+++ b/lib/api.js
@@ -71,6 +71,9 @@ function buildApiRequest (incomingRequest, routes) {
 	if (incomingRequest.headers && incomingRequest.headers.host) {
 		apiRequest.qs.host = incomingRequest.headers.host;
 	}
+	if (incomingRequest.headers && incomingRequest.headers['user-agent']) {
+		apiRequest.qs.useragent = incomingRequest.headers['user-agent'];
+	}
 	if (incomingRequest.headers && incomingRequest.headers.cookie) {
 		apiRequest.headers.Cookie = incomingRequest.headers.cookie;
 	}

--- a/test/integration/tests.js
+++ b/test/integration/tests.js
@@ -88,6 +88,15 @@ describe('Thundermole ➞ Default API ➞ Default Backend', function () {
 
 	});
 
+	describeRequest('GET', '/', {'User-Agent': 'foo'}, function () {
+
+		it('should send the `User-Agent` header to the API', function () {
+			var query = url.parse(this.testApps.apiDefault.lastRequest.url, true).query;
+			assert.strictEqual(query.useragent, 'foo');
+		});
+
+	});
+
 	describeRequest('GET', '/headers', null, function () {
 
 		it('should respond with a 200 status', function () {

--- a/test/unit/lib/api.js
+++ b/test/unit/lib/api.js
@@ -19,6 +19,7 @@
 
 var assert = require('proclaim');
 var mockery = require('mockery');
+var pkg = require('../../../package.json');
 var sinon = require('sinon');
 
 describe('lib/api', function () {
@@ -206,6 +207,10 @@ describe('lib/api', function () {
 
 			it('should have a `headers.Cookie` property set to the cookies from the original request', function () {
 				assert.deepEqual(builtRequest.headers.Cookie, 'cookies!');
+			});
+
+			it('should have a `headers[\'User-Agent\']` property set to "Thundermole/<version>"', function () {
+				assert.deepEqual(builtRequest.headers['User-Agent'], 'Thundermole/' + pkg.version);
 			});
 
 			it('should have a `json` property set to `true`', function () {

--- a/test/unit/lib/api.js
+++ b/test/unit/lib/api.js
@@ -158,6 +158,7 @@ describe('lib/api', function () {
 			incomingRequest.url = 'http://example.com/foo/bar?baz=qux';
 			incomingRequest.headers.cookie = 'cookies!';
 			incomingRequest.headers.host = 'example.com';
+			incomingRequest.headers['user-agent'] = 'UA';
 			incomingRequest.method = 'POST';
 			routes = {
 				foo: 'foo-route'
@@ -189,12 +190,16 @@ describe('lib/api', function () {
 				assert.strictEqual(builtRequest.qs.method, 'POST');
 			});
 
-			it('should have a `qs.host` property set to the host header from the original request', function () {
+			it('should have a `qs.host` property set to the Host header from the original request', function () {
 				assert.strictEqual(builtRequest.qs.host, 'example.com');
 			});
 
 			it('should have a `qs.resource` property set to the path/query of the original request', function () {
 				assert.strictEqual(builtRequest.qs.resource, '/foo/bar?baz=qux');
+			});
+
+			it('should have a `qs.useragent` property set to the User-Agent header of the original request', function () {
+				assert.strictEqual(builtRequest.qs.useragent, 'UA');
 			});
 
 			it('should have a `headers` property set to an object', function () {


### PR DESCRIPTION
This PR addresses #34.

## Send a Thundermole User-Agent header to the API

This will help API's debug potential issues with Thundermole as the version being used is included in the User-Agent header.

## Send the original request's User-Agent to the API

This allows the API to route requests based on User-Agent
